### PR TITLE
Make Constants unconstructable

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -223,7 +223,6 @@ public final class Constants {
   public static final class IndexerConstants {
     private IndexerConstants() {}
 
-
     public static final int kFeederMotorID = 20; // This ID confirmed
     public static final int kSpindexerMotorID = 15; // This id not confirmed
 
@@ -274,9 +273,9 @@ public final class Constants {
   // ==================== APRIL TAG FIELD LAYOUT ====================
 
   /**
-   * AprilTag positions on the field
-   * <br>
-   * Format: <code>HashMap&lt;TagID, double[]{X_inches, Y_inches, Z_inches, Yaw_degrees, Pitch_degrees}&rt;</code>
+   * AprilTag positions on the field <br>
+   * Format: <code>
+   * HashMap&lt;TagID, double[]{X_inches, Y_inches, Z_inches, Yaw_degrees, Pitch_degrees}&rt;</code>
    */
   public static final class AprilTagMaps {
     private AprilTagMaps() {}

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -13,6 +13,8 @@ public final class Constants {
 
   /** Game timing constants for REBUILT */
   public static final class GameConstants {
+    private GameConstants() {}
+
     // Match period durations (seconds)
     public static final double AUTO_DURATION = 20.0; // 0:00 - 0:20
     public static final double TELEOP_DURATION = 150.0; // 2:30 total
@@ -38,6 +40,8 @@ public final class Constants {
 
   /** Controller port assignments */
   public static final class ControllerConstants {
+    private ControllerConstants() {}
+
     public static final int DRIVER_CONTROLLER_PORT = 0;
     public static final int OPERATOR_CONTROLLER_PORT = 1;
 
@@ -47,6 +51,8 @@ public final class Constants {
 
   /** Drivetrain constants */
   public static final class DrivetrainConstants {
+    private DrivetrainConstants() {}
+
     // ==================== SPEEDS ====================
     // These are the ABSOLUTE maximums - derived from TunerConstants.kSpeedAt12Volts
     // The robot physically cannot exceed these values
@@ -92,6 +98,8 @@ public final class Constants {
 
   /** Intake constants (placeholder) */
   public static final class IntakeConstants {
+    private IntakeConstants() {}
+
     public static final double INTAKE_SPEED = -0.5;
     public static final int INTAKE_MOTOR_ID = 19; // TODO: Make real
     public static final int PIVOT_ENCODER_ID = 1; // TODO: Make real
@@ -102,6 +110,8 @@ public final class Constants {
 
   /** Shooter constants (placeholder) */
   public static final class ShooterConstants {
+    private ShooterConstants() {}
+
     // Target RPM values (will vary based on distance)
     public static final double SHOOTER_IDLE_RPM = 0;
     public static final double SHOOTER_SPINUP_RPM = 3000;
@@ -116,6 +126,8 @@ public final class Constants {
 
   /** Climber constants (placeholder) */
   public static final class ClimberConstants {
+    private ClimberConstants() {}
+
     // Climber arm positions (encoder units - fill in with actual values later)
     public static final double CLIMBER_STOWED_POSITION = 0;
     public static final double CLIMBER_L1_REACH_POSITION = 50;
@@ -129,6 +141,8 @@ public final class Constants {
 
   /** State machine timing constants */
   public static final class StateMachineConstants {
+    private StateMachineConstants() {}
+
     // Rumble feedback durations (seconds)
     public static final double RUMBLE_SHORT = 0.15;
     public static final double RUMBLE_MEDIUM = 0.3;
@@ -150,6 +164,8 @@ public final class Constants {
 
   /** Vision/Limelight constants (placeholder) */
   public static final class VisionConstants {
+    private VisionConstants() {}
+
     public static final String LIMELIGHT_NAME = "limelight";
 
     // Pipeline IDs
@@ -205,6 +221,8 @@ public final class Constants {
   }
 
   public static final class IndexerConstants {
+    private IndexerConstants() {}
+
 
     public static final int kFeederMotorID = 20; // This ID confirmed
     public static final int kSpindexerMotorID = 15; // This id not confirmed
@@ -257,10 +275,12 @@ public final class Constants {
 
   /**
    * AprilTag positions on the field
-   *
-   * <p>Format: HashMap<TagID, double[]{X_inches, Y_inches, Z_inches, Yaw_degrees, Pitch_degrees}>
+   * <br>
+   * Format: <code>HashMap&lt;TagID, double[]{X_inches, Y_inches, Z_inches, Yaw_degrees, Pitch_degrees}&rt;</code>
    */
   public static final class AprilTagMaps {
+    private AprilTagMaps() {}
+
     public static final java.util.HashMap<Integer, double[]> aprilTagMap =
         new java.util.HashMap<>();
 

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -9,6 +9,7 @@ package frc.robot;
  * configuration
  */
 public final class Constants {
+  private Constants() {}
 
   /** Game timing constants for REBUILT */
   public static final class GameConstants {


### PR DESCRIPTION
Previously, you could do

```java
var constants = new Constants(); // ??? 🤔🤔🤔🤔
```

This is clearly wrong, so I've fixed it by making the only constructor private.