### PR TITLE
fix: bad volatile usage in networked double

### DIFF
--- a/src/main/java/frc/robot/lib/NetworkedLib/NetworkedPID.java
+++ b/src/main/java/frc/robot/lib/NetworkedLib/NetworkedPID.java
@@ -11,9 +11,9 @@ public class NetworkedPID extends PIDController {
 
   private String name;
 
-  private NetworkedDouble networkedKp;
-  private NetworkedDouble networkedKi;
-  private NetworkedDouble networkedKd;
+  private NetworkedDouble networkedKP;
+  private NetworkedDouble networkedKI;
+  private NetworkedDouble networkedKD;
   /**
    * Allocates a PIDController with the given constants for kp, ki, and kd and a default period of
    * 0.02 seconds.
@@ -79,9 +79,9 @@ public class NetworkedPID extends PIDController {
   }
 
   private void setupNT(double kp, double ki, double kd) {
-    this.networkedKp = new NetworkedDouble("/NetworkedLib/" + name + "/kp", kp);
-    this.networkedKi = new NetworkedDouble("/NetworkedLib/" + name + "/ki", ki);
-    this.networkedKd = new NetworkedDouble("/NetworkedLib/" + name + "/kd", kd);
+    networkedKP = new NetworkedDouble("/NetworkedLib/" + name + "/kp", kp);
+    networkedKI = new NetworkedDouble("/NetworkedLib/" + name + "/ki", ki);
+    networkedKD = new NetworkedDouble("/NetworkedLib/" + name + "/kd", kd);
   }
 
   /**
@@ -98,6 +98,6 @@ public class NetworkedPID extends PIDController {
 
   /** Updates the current PID with new values */
   public void updatePID() {
-    this.setPID(networkedKp.get(), networkedKi.get(), networkedKd.get());
+    this.setPID(networkedKP.get(), networkedKI.get(), networkedKD.get());
   }
 }

--- a/src/main/java/frc/robot/lib/NetworkedLib/NetworkedTalonFX.java
+++ b/src/main/java/frc/robot/lib/NetworkedLib/NetworkedTalonFX.java
@@ -18,10 +18,10 @@ public class NetworkedTalonFX extends TalonFX {
   // networked prefix to just to avoid ambigiouity between actual values and their networked
   // partners
   private NetworkedDouble networkedKA; // acceleration gain
-  private NetworkedDouble networkedkD; // derivative gain
-  private NetworkedDouble networkedkG; // gravity gain
-  private NetworkedDouble networkedkI; // integral gain
-  private NetworkedDouble networkedkP; // proprotional gain
+  private NetworkedDouble networkedKD; // derivative gain
+  private NetworkedDouble networkedKG; // gravity gain
+  private NetworkedDouble networkedKI; // integral gain
+  private NetworkedDouble networkedKP; // proprotional gain
   private NetworkedDouble networkedKS; // static constant (static friction)
   private NetworkedDouble networkedKV; // velo feed forward
 
@@ -37,7 +37,7 @@ public class NetworkedTalonFX extends TalonFX {
     super(ID, canbus);
     instanceCount++;
 
-    this.name = "NetworkedTalonFX_" + instanceCount;
+    name = "NetworkedTalonFX_" + instanceCount;
   }
 
   /**
@@ -50,18 +50,21 @@ public class NetworkedTalonFX extends TalonFX {
     super(ID, canbus);
     instanceCount++;
 
-    this.name = "NetworkedTalonFX_" + instanceCount;
+    name = "NetworkedTalonFX_" + instanceCount;
   }
 
   /**
    * Constructor with name setter
    *
    * @param ID motor ID
-   * @param canbus canbus name
+   * @param canbus CAN bus name
    * @param name motor name for Network Tables
+   * @deprecated Constructing devices with a CAN bus string is deprecated for removal in the 2027
+   *     season. Construct devices using a {@link CANBus} instance instead.
    */
+  @Deprecated(since = "2026", forRemoval = true)
   public NetworkedTalonFX(int ID, String canbus, String name) {
-    super(ID, canbus);
+    this(ID, new CANBus(canbus), name);
     instanceCount++;
 
     this.name = name;
@@ -83,13 +86,13 @@ public class NetworkedTalonFX extends TalonFX {
 
   private void setupNT(
       double kA, double kD, double kG, double kI, double kP, double kS, double kV) {
-    this.networkedKA = new NetworkedDouble("/NetworkedLib/" + this.name + "/kA", kA);
-    this.networkedkD = new NetworkedDouble("/NetworkedLib/" + this.name + "/kD", kD);
-    this.networkedkG = new NetworkedDouble("/NetworkedLib/" + this.name + "/kG", kG);
-    this.networkedkI = new NetworkedDouble("/NetworkedLib/" + this.name + "/kI", kI);
-    this.networkedkP = new NetworkedDouble("/NetworkedLib/" + this.name + "/kP", kP);
-    this.networkedKS = new NetworkedDouble("/NetworkedLib/" + this.name + "/kS", kS);
-    this.networkedKV = new NetworkedDouble("/NetworkedLib/" + this.name + "/kV", kV);
+    networkedKA = new NetworkedDouble("/NetworkedLib/" + name + "/kA", kA);
+    networkedKD = new NetworkedDouble("/NetworkedLib/" + name + "/kD", kD);
+    networkedKG = new NetworkedDouble("/NetworkedLib/" + name + "/kG", kG);
+    networkedKI = new NetworkedDouble("/NetworkedLib/" + name + "/kI", kI);
+    networkedKP = new NetworkedDouble("/NetworkedLib/" + name + "/kP", kP);
+    networkedKS = new NetworkedDouble("/NetworkedLib/" + name + "/kS", kS);
+    networkedKV = new NetworkedDouble("/NetworkedLib/" + name + "/kV", kV);
   }
 
   /**
@@ -100,9 +103,9 @@ public class NetworkedTalonFX extends TalonFX {
    * @param config The TalonFXConfiguration to apply
    */
   public void applyConfiguration(TalonFXConfiguration config) {
-    this.activeConfig = config;
+    activeConfig = config;
 
-    this.getConfigurator().apply(config);
+    getConfigurator().apply(config);
     setupNT(
         activeConfig.Slot0.kA,
         activeConfig.Slot0.kD,
@@ -121,29 +124,29 @@ public class NetworkedTalonFX extends TalonFX {
   public void periodic() {
     // checks if any networked doubles have new information
     if (networkedKA.available()
-        || networkedkD.available()
-        || networkedkG.available()
-        || networkedkI.available()
-        || networkedkP.available()
+        || networkedKD.available()
+        || networkedKG.available()
+        || networkedKI.available()
+        || networkedKP.available()
         || networkedKS.available()
         || networkedKV.available()) {
 
-      // ensures values like gravity FF type and other are perserved
-      this.activeConfig.Slot0 = this.activeConfig
+      // ensures values like gravity FF type and other are preserved
+      activeConfig.Slot0 = activeConfig
           .Slot0
           .withKA(networkedKA.get())
-          .withKD(networkedkD.get())
-          .withKG(networkedkG.get())
-          .withKI(networkedkI.get())
-          .withKP(networkedkP.get())
+          .withKD(networkedKD.get())
+          .withKG(networkedKG.get())
+          .withKI(networkedKI.get())
+          .withKP(networkedKP.get())
           .withKS(networkedKS.get())
           .withKV(networkedKV.get());
 
-      // the reason we arent directly applying slot0Configs is because it leaves open more stuff to
-      // add to the networked possiblities later.
-      // in the future we could network other parts of the config (like current limits!)
+      // The reason we aren't directly applying slot0Configs is that it leaves open more stuff to
+      // add to the networked possibilities later.
+      // In the future we could network other parts of the config (like current limits).
 
-      this.getConfigurator().apply(this.activeConfig);
+      getConfigurator().apply(activeConfig);
     }
   }
 }


### PR DESCRIPTION
`volatile`-qualified member variables are not actually thread-safe to read from and write to from multiple threads, so it needed to be replaced with AtomicBoolean. `volatile` **only** ensures that writes are mirrored to other threads instead of remaining in some register inaccessible to other threads, making it unsafe for multiple threads to be reading and writing to it. AtomicBoolean is a wrapper around a boolean with atomic compare-and-swap primitives with CPU intrinsics (I think), making it properly able to be read from and mutated by multiple threads.

https://github.com/FRCTeam10079/FRCRebuilt2026-ALPHA/blob/f16a79ceeab6d2b9ecc2a72310049c4f239acfd6/src/main/java/frc/robot/lib/NetworkedLib/NetworkedDouble.java#L60-L63
is _definitely_ unsafe as the write after the read is definitely not atomic, and so the value of `newData` could be mutated between those two statements.

I've also made names more consistent and fixed some documentation comments.